### PR TITLE
Fix division by 0

### DIFF
--- a/src/core/motor_controller.cpp
+++ b/src/core/motor_controller.cpp
@@ -200,7 +200,7 @@ void MotorController::step_micros(motor_data& data, long pulses, unsigned long m
 
     data.pulses_to_correct = 0;
     float err = mcu_ticks_per_pulse - data.mcu_ticks_per_pulse;
-    if (err = 0.0) data.pulses_to_correct = 0;
+    if (err == 0.0) data.pulses_to_correct = 0;
     else data.pulses_to_correct = 1.0 / err;
 
     #ifdef DEBUG


### PR DESCRIPTION
Hi awesome project! Can't wait to build my own :)
Just a small comparison fix to prevent a division by 0.

Not sure if am missing something here, as the debug print should've always printed "inf"